### PR TITLE
Shushman/1.0 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
 notifications:
   email: false
 git:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,8 @@
-julia 0.6
+julia 0.7
 POMDPs
 StaticArrays
 Parameters
 GridInterpolations
-POMDPToolbox
+POMDPModelTools
+POMDPModels
 Plots

--- a/src/ContinuumWorld.jl
+++ b/src/ContinuumWorld.jl
@@ -1,12 +1,13 @@
 module ContinuumWorld
 
 # package code goes here
-
-importall POMDPs
+using Random
+using POMDPs
 using StaticArrays
 using Parameters
 using GridInterpolations
-using POMDPToolbox
+using POMDPModelTools
+using POMDPModels
 using Plots
 
 export
@@ -21,7 +22,7 @@ export
 
 const Vec2 = SVector{2, Float64}
 
-immutable CircularRegion
+struct CircularRegion
     center::Vec2
     radius::Float64
 end
@@ -37,7 +38,7 @@ const default_regions = [CircularRegion(Vec2(3.5, 2.5), 0.5),
 const default_rewards = [-10.0, -5.0, 10.0, 3.0]
 
 
-@with_kw immutable CWorld <: MDP{Vec2, Vec2}
+@with_kw struct CWorld <: MDP{Vec2, Vec2}
     xlim::Tuple{Float64, Float64}                   = (0.0, 10.0)
     ylim::Tuple{Float64, Float64}                   = (0.0, 10.0)
     reward_regions::Vector{CircularRegion}          = default_regions

--- a/src/ContinuumWorld.jl
+++ b/src/ContinuumWorld.jl
@@ -2,6 +2,7 @@ module ContinuumWorld
 
 # package code goes here
 using Random
+using LinearAlgebra
 using POMDPs
 using StaticArrays
 using Parameters
@@ -27,7 +28,7 @@ struct CircularRegion
     radius::Float64
 end
 
-Base.in(v::Vec2, r::CircularRegion) = norm(v-r.center) <= r.radius
+Base.in(v::Vec2, r::CircularRegion) = LinearAlgebra.norm(v-r.center) <= r.radius
 
 const card_and_stay = [Vec2(1.0, 0.0), Vec2(-1.0, 0.0), Vec2(0.0, 1.0), Vec2(0.0, -1.0), Vec2(0.0, 0.0)]
 const cardinal = [Vec2(1.0, 0.0), Vec2(-1.0, 0.0), Vec2(0.0, 1.0), Vec2(0.0, -1.0)]
@@ -49,15 +50,15 @@ const default_rewards = [-10.0, -5.0, 10.0, 3.0]
     discount::Float64                               = 0.95
 end
 
-actions(w::CWorld) = w.actions
-n_actions(w::CWorld) = length(w.actions)
-discount(w::CWorld) = w.discount
+POMDPs.actions(w::CWorld) = w.actions
+POMDPs.n_actions(w::CWorld) = length(w.actions)
+POMDPs.discount(w::CWorld) = w.discount
 
-function generate_s(w::CWorld, s::AbstractVector, a::AbstractVector, rng::AbstractRNG)
+function POMDPs.generate_s(w::CWorld, s::AbstractVector, a::AbstractVector, rng::AbstractRNG)
     return s + a + w.stdev*randn(rng, Vec2)
 end
 
-function reward(w::CWorld, s::AbstractVector, a::AbstractVector, sp::AbstractVector) # XXX inefficient
+function POMDPs.reward(w::CWorld, s::AbstractVector, a::AbstractVector, sp::AbstractVector) # XXX inefficient
     rew = 0.0
     for (i,r) in enumerate(w.reward_regions)
         if sp in r
@@ -67,7 +68,7 @@ function reward(w::CWorld, s::AbstractVector, a::AbstractVector, sp::AbstractVec
     return rew
 end
 
-function isterminal(w::CWorld, s::Vec2) # XXX inefficient
+function POMDPs.isterminal(w::CWorld, s::Vec2) # XXX inefficient
     for r in w.terminal
         if s in r
             return true
@@ -76,7 +77,7 @@ function isterminal(w::CWorld, s::Vec2) # XXX inefficient
     return false
 end
 
-function initial_state(w::CWorld, rng::AbstractRNG)
+function POMDPs.initialstate(w::CWorld, rng::AbstractRNG)
     x = w.xlim[1] + (w.xlim[2] - w.xlim[1]) * rand(rng)
     y = w.ylim[1] + (w.ylim[2] - w.ylim[1]) * rand(rng)
     return Vec2(x,y)

--- a/src/ContinuumWorld.jl
+++ b/src/ContinuumWorld.jl
@@ -10,6 +10,7 @@ using GridInterpolations
 using POMDPModelTools
 using POMDPModels
 using Plots
+plotly()
 
 export
     CWorld,

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -1,11 +1,11 @@
-immutable GIValue{G <: AbstractGrid}
+struct GIValue{G <: AbstractGrid}
     grid::G
     gdata::Vector{Float64}
 end
 
 evaluate(v::GIValue, s::AbstractVector{Float64}) = interpolate(v.grid, v.gdata, convert(Vector{Float64}, s))
 
-@with_kw type CWorldSolver{G<:AbstractGrid, RNG<:AbstractRNG} <: Solver
+@with_kw struct CWorldSolver{G<:AbstractGrid, RNG<:AbstractRNG} <: Solver
     grid::G                     = RectangleGrid(linspace(0.0,10.0, 30), linspace(0.0, 10.0, 30))
     max_iters::Int              = 50
     tol::Float64                = 0.01

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -11,7 +11,7 @@ evaluate(v::GIValue, s::AbstractVector{Float64}) = interpolate(v.grid, v.gdata, 
     tol::Float64                = 0.01
     m::Int                      = 20
     value_hist::AbstractVector  = []
-    rng::RNG                    = Base.GLOBAL_RNG
+    rng::RNG                    = Random.GLOBAL_RNG
 end
 
 struct CWorldPolicy{V} <: Policy
@@ -32,7 +32,7 @@ function POMDPs.solve(sol::CWorldSolver, w::CWorld)
                 newdata[i] = 0.0
             else
                 best_Qsum = -Inf
-                for a in iterator(actions(w, s))
+                for a in actions(w, s)
                     Qsum = 0.0
                     for j in 1:sol.m
                         sp, r = generate_sr(w, s, a, sol.rng)
@@ -51,7 +51,7 @@ function POMDPs.solve(sol::CWorldSolver, w::CWorld)
     print("\nextracting policy...     ")
 
     Qs = Vector{GIValue}(undef,n_actions(w))
-    acts = collect(iterator(actions(w)))
+    acts = collect(actions(w))
     for j in 1:n_actions(w)
         a = acts[j]
         qdata = similar(val.gdata)

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -7,10 +7,10 @@ mutable struct CWorldVis
 end
 
 function CWorldVis(w::CWorld;
-                   s=Union{Vec2, Nothing}(),
-                   f=Union{Function, Nothing}(),
-                   g=Union{AbstractGrid, Nothing}(),
-                   title=Union{String, Nothing}())
+                   s=nothing,
+                   f=nothing,
+                   g=nothing,
+                   title=nothing)
     return CWorldVis(w, s, f, g, title)
 end
 
@@ -18,18 +18,18 @@ end
     xlim --> v.w.xlim
     ylim --> v.w.ylim
     aspect_ratio --> 1
-    title --> get(v.title, "Continuum World")
+    title --> (v.title === nothing) ? "Continuum World" : v.title
     if v.f !== nothing
         @series begin
-            f = get(v.f)
+            f = v.f
             width = v.w.xlim[2]-v.w.xlim[1]
             height = v.w.ylim[2]-v.w.ylim[1]
             n = 200 # number of pixels
             nx = round(Int, sqrt(n^2*width/height))
             ny = round(Int, sqrt(n^2*height/width))
-            xs = linspace(v.w.xlim..., nx)
-            ys = linspace(v.w.ylim..., ny)
-            zg = Array{Float64}(nx, ny)
+            xs = range(v.w.xlim[1], stop=v.w.xlim[2], length=nx)
+            ys = range(v.w.ylim[1], stop=v.w.ylim[2], length=ny)
+            zg = Array{Float64}(undef, nx, ny)
             for i in 1:nx
                 for j in 1:ny
                     zg[j,i] = f(Vec2(xs[i], ys[j]))
@@ -42,7 +42,7 @@ end
     end
     if v.g !== nothing
         @series begin
-            g = get(v.g)
+            g = v.g
             xs = collect(ind2x(g, i)[1] for i in 1:length(g))
             ys = collect(ind2x(g, i)[2] for i in 1:length(g))
             label --> "Grid"

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -1,17 +1,16 @@
-
-type CWorldVis
+mutable struct CWorldVis
     w::CWorld
-    s::Nullable{Vec2}
-    f::Nullable{Function}
-    g::Nullable{AbstractGrid}
-    title::Nullable{String}
+    s::Union{Vec2, Nothing}
+    f::Union{Function, Nothing}
+    g::Union{AbstractGrid, Nothing}
+    title::Union{String, Nothing}
 end
 
 function CWorldVis(w::CWorld;
-                   s=Nullable{Vec2}(),
-                   f=Nullable{Function}(),
-                   g=Nullable{AbstractGrid}(),
-                   title=Nullable{String}())
+                   s=Union{Vec2, Nothing}(),
+                   f=Union{Function, Nothing}(),
+                   g=Union{AbstractGrid, Nothing}(),
+                   title=Union{String, Nothing}())
     return CWorldVis(w, s, f, g, title)
 end
 
@@ -20,7 +19,7 @@ end
     ylim --> v.w.ylim
     aspect_ratio --> 1
     title --> get(v.title, "Continuum World")
-    if !isnull(v.f)
+    if v.f !== nothing
         @series begin
             f = get(v.f)
             width = v.w.xlim[2]-v.w.xlim[1]
@@ -41,7 +40,7 @@ end
             xs, ys, zg
         end
     end
-    if !isnull(v.g)
+    if v.g !== nothing
         @series begin
             g = get(v.g)
             xs = collect(ind2x(g, i)[1] for i in 1:length(g))

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,5 @@
 POMDPs
 POMDPModelTools
 POMDPModels
+POMDPSimulators
 Plots

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,4 @@
+POMDPs
+POMDPModelTools
+POMDPModels
+Plots

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using ContinuumWorld
 using POMDPs
 using POMDPModelTools
 using POMDPModels
+using POMDPSimulators
 using Test
 using Plots
 using Random

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,10 @@
 using ContinuumWorld
 using POMDPs
-using POMDPToolbox
-using Base.Test
+using POMDPModelTools
+using POMDPModels
+using Test
 using Plots
+using Random
 
 w = CWorld()
 


### PR DESCRIPTION
Compiles but the test gives an unenviable error trace:
```
┌ Warning: POMDPs.jl: Could not find or synthesize generate_sr(::CWorld, ::Array, ::Array, ::MersenneTwister).
└ @ POMDPs ~/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:270
┌ Error: Exception while generating log record in module POMDPs at /home/shushman/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:270
│   exception =
│    task switch not allowed from inside staged nor pure functions
│    Stacktrace:
│     [1] try_yieldto(::typeof(Base.ensure_rescheduled), ::Base.RefValue{Task}) at ./event.jl:187
│     [2] wait() at ./event.jl:255
│     [3] uv_write(::Base.TTY, ::Ptr{UInt8}, ::UInt64) at ./stream.jl:786
│     [4] unsafe_write(::Base.TTY, ::Ptr{UInt8}, ::UInt64) at ./stream.jl:834
│     [5] macro expansion at ./io.jl:509 [inlined]
│     [6] write(::Base.TTY, ::Array{UInt8,1}) at ./io.jl:532
│     [7] #handle_message#2(::Nothing, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::Logging.ConsoleLogger, ::Base.CoreLogging.LogLevel, ::String, ::Module, ::String, ::Symbol, ::String, ::Int64) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Logging/src/ConsoleLogger.jl:161
│     [8] handle_message at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Logging/src/ConsoleLogger.jl:100 [inlined]
│     [9] macro expansion at ./logging.jl:322 [inlined]
│     [10] failed_synth_warning(::Tuple{typeof(generate_sr),DataType}, ::Array{Tuple{Bool,Function,DataType},1}, ::Array{Tuple{Bool,Function,DataType},1}) at /home/shushman/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:270
│     [11] #s35#4(::Any, ::Any, ::Any, ::Any, ::Any) at /home/shushman/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:63
│     [12] (::Core.GeneratedFunctionStub)(::Any, ::Vararg{Any,N} where N) at ./boot.jl:506
│     [13] get_staged(::Core.MethodInstance) at ./compiler/utilities.jl:91
│     [14] retrieve_code_info(::Core.MethodInstance) at ./compiler/utilities.jl:112
│     [15] Type at ./compiler/inferencestate.jl:117 [inlined]
│     [16] typeinf_ext(::Core.MethodInstance, ::Core.Compiler.Params) at ./compiler/typeinfer.jl:565
│     [17] typeinf_ext(::Core.MethodInstance, ::UInt64) at ./compiler/typeinfer.jl:604
│     [18] top-level scope at none:0
│     [19] include at ./boot.jl:317 [inlined]
│     [20] include_relative(::Module, ::String) at ./loading.jl:1038
│     [21] include(::Module, ::String) at ./sysimg.jl:29
│     [22] include(::String) at ./client.jl:388
│     [23] top-level scope at none:0
│     [24] eval(::Module, ::Any) at ./boot.jl:319
│     [25] macro expansion at ./logging.jl:317 [inlined]
│     [26] exec_options(::Base.JLOptions) at ./client.jl:219
│     [27] _start() at ./client.jl:421
└ @ POMDPs ~/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:270
Exception handling log message: 
Hint for fixing warning above: Either implement generate_sr(::CWorld, ::Array, ::Array, ::MersenneTwister) directly, or, to automatically synthesize it, implement the following methods from the explicit interface:
┌ Warning: POMDPs.jl: Could not find or synthesize generate_sr(::CWorld, ::Array, ::Array, ::MersenneTwister).
└ @ POMDPs ~/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:270
┌ Error: Exception while generating log record in module POMDPs at /home/shushman/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:270
│   exception =
│    task switch not allowed from inside staged nor pure functions
│    Stacktrace:
│     [1] try_yieldto(::typeof(Base.ensure_rescheduled), ::Base.RefValue{Task}) at ./event.jl:187
│     [2] wait() at ./event.jl:255
│     [3] uv_write(::Base.TTY, ::Ptr{UInt8}, ::UInt64) at ./stream.jl:786
│     [4] unsafe_write(::Base.TTY, ::Ptr{UInt8}, ::UInt64) at ./stream.jl:834
│     [5] macro expansion at ./io.jl:509 [inlined]
│     [6] write(::Base.TTY, ::Array{UInt8,1}) at ./io.jl:532
│     [7] #handle_message#2(::Nothing, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::Logging.ConsoleLogger, ::Base.CoreLogging.LogLevel, ::String, ::Module, ::String, ::Symbol, ::String, ::Int64) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Logging/src/ConsoleLogger.jl:161
│     [8] handle_message at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Logging/src/ConsoleLogger.jl:100 [inlined]
│     [9] macro expansion at ./logging.jl:322 [inlined]
│     [10] failed_synth_warning(::Tuple{typeof(generate_sr),DataType}, ::Array{Tuple{Bool,Function,DataType},1}, ::Array{Tuple{Bool,Function,DataType},1}) at /home/shushman/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:270
│     [11] #s35#4(::Any, ::Any, ::Any, ::Any, ::Any) at /home/shushman/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:63
│     [12] (::Core.GeneratedFunctionStub)(::Any, ::Vararg{Any,N} where N) at ./boot.jl:506
│     [13] top-level scope at none:0
│     [14] include at ./boot.jl:317 [inlined]
│     [15] include_relative(::Module, ::String) at ./loading.jl:1038
│     [16] include(::Module, ::String) at ./sysimg.jl:29
│     [17] include(::String) at ./client.jl:388
│     [18] top-level scope at none:0
│     [19] eval(::Module, ::Any) at ./boot.jl:319
│     [20] macro expansion at ./logging.jl:317 [inlined]
│     [21] exec_options(::Base.JLOptions) at ./client.jl:219
│     [22] _start() at ./client.jl:421
└ @ POMDPs ~/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:270
Exception handling log message: 
Hint for fixing warning above: Either implement generate_sr(::CWorld, ::Array, ::Array, ::MersenneTwister) directly, or, to automatically synthesize it, implement the following methods from the explicit interface:
ERROR: LoadError: task switch not allowed from inside staged nor pure functions
Stacktrace:
 [1] try_yieldto(::typeof(Base.ensure_rescheduled), ::Base.RefValue{Task}) at ./event.jl:187
 [2] wait() at ./event.jl:255
 [3] uv_write(::Base.TTY, ::Ptr{UInt8}, ::UInt64) at ./stream.jl:786
 [4] unsafe_write(::Base.TTY, ::Ptr{UInt8}, ::UInt64) at ./stream.jl:834
 [5] print(::Base.TTY, ::String, ::Char) at ./gcutils.jl:87
 [6] println(::Base.TTY, ::String) at ./strings/io.jl:69
 [7] println(::String) at ./coreio.jl:4
 [8] macro expansion at ./logging.jl:307 [inlined]
 [9] failed_synth_warning(::Tuple{typeof(generate_sr),DataType}, ::Array{Tuple{Bool,Function,DataType},1}, ::Array{Tuple{Bool,Function,DataType},1}) at /home/shushman/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:270
 [10] #s35#4(::Any, ::Any, ::Any, ::Any, ::Any) at /home/shushman/.julia/packages/POMDPs/pvByv/src/generative_impl.jl:63
 [11] (::Core.GeneratedFunctionStub)(::Any, ::Vararg{Any,N} where N) at ./boot.jl:506
 [12] top-level scope at none:0
 [13] include at ./boot.jl:317 [inlined]
 [14] include_relative(::Module, ::String) at ./loading.jl:1038
 [15] include(::Module, ::String) at ./sysimg.jl:29
 [16] include(::String) at ./client.jl:388
 [17] top-level scope at none:0
in expression starting at /home/shushman/.julia/dev/ContinuumWorld/test/runtests.jl:11
ERROR: Package ContinuumWorld errored during testing
```